### PR TITLE
feat: add Excel (XLSX) export for task time entries

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -24,6 +24,7 @@ return [
 		["name" => "page#deleteTime", "url" => "/times/delete", "verb" => "POST"],
 		["name" => "page#payTime", "url" => "/times/paid", "verb" => "POST"],
 		["name" => "page#unpayTime", "url" => "/times/unpaid", "verb" => "POST"],
+		["name" => "page#exportTaskXlsx", "url" => "/times/export/xlsx", "verb" => "GET"],
 		["name" => "page#updateSettings", "url" => "/settings", "verb" => "POST"],
 		["name" => "page#tools", "url" => "/tools", "verb" => "GET"],
 		["name" => "page#settings", "url" => "/settings", "verb" => "GET"],

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -19,6 +19,7 @@ use OCA\TimeManager\Db\StorageHelper;
 use OCA\TimeManager\Helper\UUID;
 use OCA\TimeManager\Helper\PHP_Svelte;
 use OCA\TimeManager\Helper\ArrayToCSV;
+use OCA\TimeManager\Helper\ArrayToXLSX;
 use OCA\TimeManager\Helper\ISODate;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Services\IAppConfig;
@@ -287,8 +288,8 @@ class PageController extends Controller {
 				$hours = $time->getDurationInHours();
 				$times_grouped_by_client[$client->getUuid()]->totalHours += $hours;
 				$hours_total += $hours;
-				// Prepare a row for the CSV
-				if ($format === "csv") {
+				// Prepare a row for the CSV/XLSX export
+				if ($format === "csv" || $format === "xlsx") {
 					$date_time_zone = new \DateTimeZone($timezone);
 
 					$start_date_time = new \DateTime($time->getStart(), new \DateTimeZone("UTC"));
@@ -325,6 +326,15 @@ class PageController extends Controller {
 			$filename = $start === $end ? $this->l->t("report_%s.csv", [$start]) : $this->l->t("report_%s_%s.csv", [$start, $end]);
 			// Download as CSV
 			return new DataDownloadResponse(ArrayToCSV::convert($all_time_entries), $filename, "text/csv");
+		} elseif ($format === "xlsx") {
+			// Prepare filename with daterange
+			$filename = $start === $end ? $this->l->t("report_%s.xlsx", [$start]) : $this->l->t("report_%s_%s.xlsx", [$start, $end]);
+			// Download as XLSX
+			return new DataDownloadResponse(
+				ArrayToXLSX::convert($all_time_entries, "Time Report"),
+				$filename,
+				"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+			);
 		} else {
 			$store = [
 				"clients" => array_map(function ($oneClient) {
@@ -956,6 +966,13 @@ class PageController extends Controller {
 		$task_uuid = isset($task_data) && count($task_data) > 0 ? $task_data[0]->getUuid() : "";
 		$task_name = isset($task_data) && count($task_data) > 0 ? $task_data[0]->getName() : "";
 
+		$user_server_timezone = $this->serverConfig->getUserValue(
+			$this->userId,
+			'core',
+			'timezone',
+			'UTC'
+		);
+
 		$form_props = [
 			"action" => $this->urlGenerator->linkToRoute("timemanager.page.times") . "?task=" . $task_uuid,
 			"editAction" => $this->urlGenerator->linkToRoute("timemanager.page.tasks"),
@@ -1003,6 +1020,7 @@ class PageController extends Controller {
 			"canEdit" => $sharedBy === null,
 			"latestEntries" => $latestEntries,
 			"hasSharedTimeEntries" => $hasSharedTimeEntries,
+			"user_server_timezone" => $user_server_timezone,
 		]);
 	}
 
@@ -1097,117 +1115,4 @@ class PageController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
-	function payTime($uuid) {
-		$time = $this->storageHelper->getTimeEntryByIdForEditing($uuid);
-		if ($time) {
-			$commit = UUID::v4();
-			$this->storageHelper->insertCommit($commit);
-			// Adjust payment status object
-			$time->setChanged(date("Y-m-d H:i:s"));
-			$time->setCommit($commit);
-			$time->setPaymentStatus("paid");
-			$this->timeMapper->update($time);
-
-			return new RedirectResponse(
-				$this->urlGenerator->linkToRoute("timemanager.page.times") . "?task=" . $time->getTaskUuid()
-			);
-		}
-
-		return new NotFoundException("Time entry could not be found");
-	}
-
-	/**
-	 * @NoAdminRequired
-	 */
-	function unpayTime($uuid) {
-		$time = $this->storageHelper->getTimeEntryByIdForEditing($uuid);
-		if ($time) {
-			$commit = UUID::v4();
-			$this->storageHelper->insertCommit($commit);
-			// Adjust payment status
-			$time->setChanged(date("Y-m-d H:i:s"));
-			$time->setCommit($commit);
-			$time->setPaymentStatus("");
-			$this->timeMapper->update($time);
-
-			return new RedirectResponse(
-				$this->urlGenerator->linkToRoute("timemanager.page.times") . "?task=" . $time->getTaskUuid()
-			);
-		}
-
-		return new NotFoundException("Time entry could not be found");
-	}
-
-	/**
-	 * @NoAdminRequired
-	 */
-	function updateSettings($timemanager_input_method): RedirectResponse {
-        $input_method = InputMethods::Decimal;
-        if ($timemanager_input_method === InputMethods::Minutes) {
-            $input_method = InputMethods::Minutes;
-        }
-
-		$this->config->setAppValueString(
-            self::INPUT_METHOD_SETTING_NAME,
-			$input_method
-		);
-
-		return new RedirectResponse($this->urlGenerator->linkToRoute("timemanager.page.settings"));
-	}
-
-	/**
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
-	 */
-	function tools() {
-		$all_clients = $this->clientMapper->findActiveForCurrentUser("name");
-		$all_projects = $this->projectMapper->findActiveForCurrentUser("name");
-		$all_tasks = $this->taskMapper->findActiveForCurrentUser("name");
-		$all_times = $this->timeMapper->findActiveForCurrentUser();
-
-		$store = [
-			"clients" => $all_clients,
-			"projects" => $all_projects,
-			"tasks" => $all_tasks,
-			"times" => $all_times,
-			"action" => $this->urlGenerator->linkToRoute("timemanager.page.tools"),
-			"syncApiUrl" => $this->urlGenerator->linkToRoute("timemanager.t_api.updateObjectsFromWeb"),
-			"requestToken" => $this->requestToken,
-			"isServer" => true,
-		];
-
-		return new TemplateResponse("timemanager", "tools", [
-			"clients" => $all_clients,
-			"projects" => $all_projects,
-			"tasks" => $all_tasks,
-			"times" => $all_times,
-			"store" => json_encode($store),
-			"page" => "tools",
-		]);
-	}
-
-    /**
-     * @NoAdminRequired
-     * @NoCSRFRequired
-     */
-    function settings(): TemplateResponse {
-        $store = [
-            "requestToken" => $this->requestToken,
-            "isServer" => false,
-            "settingsAction" => $this->urlGenerator->linkToRoute("timemanager.page.updateSettings"),
-            "settings" => $this->getSettings(),
-        ];
-
-        return new TemplateResponse("timemanager", "settings", [
-            "page" => "settings",
-            "store" => json_encode($store),
-        ]);
-    }
-
-    private function getSettings(): array {
-        return [
-            self::INPUT_METHOD_SETTING_NAME => $this->config->getAppValueString(self::INPUT_METHOD_SETTING_NAME, InputMethods::Decimal),
-            self::FULL_DATE_FORMAT_SETTING_NAME => $this->fullDateFormat,
-        ];
-    }
-}
+	function p

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -1114,5 +1114,73 @@ class PageController extends Controller {
 
 	/**
 	 * @NoAdminRequired
+	 * @NoCSRFRequired
 	 */
-	function p
+	function exportTaskXlsx(string $task_uuid, string $timezone = "UTC"): DataDownloadResponse {
+		$task = $this->taskMapper->getActiveObjectById($task_uuid, true);
+		if (!$task) {
+			throw new NotFoundException("Task could not be found");
+		}
+
+		$project = $this->projectMapper->getActiveObjectById($task->getProjectUuid(), true);
+		if (!$project) {
+			throw new NotFoundException("Project could not be found");
+		}
+
+		$client = $this->clientMapper->getActiveObjectById($project->getClientUuid(), true);
+		if (!$client) {
+			throw new NotFoundException("Client could not be found");
+		}
+
+		$times = $this->timeMapper->getActiveObjectsByAttributeValue(
+			"task_uuid",
+			$task_uuid,
+			"start",
+			true,
+			"DESC"
+		);
+		$times = $this->storageHelper->resolveAuthorDisplayNamesForTimes($times, $this->userManager);
+
+		$rows = [];
+		$date_time_zone = new \DateTimeZone($timezone);
+
+		foreach ($times as $time) {
+			$hours = $time->getDurationInHours();
+
+			$start_date_time = new \DateTime($time->getStart(), new \DateTimeZone("UTC"));
+			$start_date_time->setTimezone($date_time_zone);
+
+			$end_date_time = new \DateTime($time->getEnd(), new \DateTimeZone("UTC"));
+			$end_date_time->setTimezone($date_time_zone);
+
+			$duration = $this->config->getAppValueString(
+				self::INPUT_METHOD_SETTING_NAME,
+				InputMethods::Decimal
+			) == InputMethods::Minutes
+				? DurationHelper::format_decimal_duration_as_time($hours)
+				: $hours;
+
+			$rows[] = [
+				"date" => $start_date_time->format("Y-m-d"),
+				"start" => $start_date_time->format("H:i"),
+				"end" => $end_date_time->format("H:i"),
+				"duration" => $duration,
+				"note" => $time->getNote(),
+				"status" => strtolower($time->getPaymentStatus()) === "paid" ? "paid" : "unpaid",
+				"author" => $time->author_display_name,
+				"task" => $task->getName(),
+				"project" => $project->getName(),
+				"client" => $client->getName(),
+			];
+		}
+
+		$safeTitle = preg_replace('/[^a-z0-9]/i', '_', $task->getName());
+		$filename = "timemanager_" . $safeTitle . ".xlsx";
+
+		return new DataDownloadResponse(
+			ArrayToXLSX::convert($rows, $task->getName()),
+			$filename,
+			"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+		);
+	}
+}

--- a/lib/Helper/ArrayToXLSX.php
+++ b/lib/Helper/ArrayToXLSX.php
@@ -1,0 +1,253 @@
+<?php
+
+namespace OCA\TimeManager\Helper;
+
+/**
+ * Generates a minimal but valid .xlsx file (Office Open XML) from an array of rows.
+ * Uses only PHP built-ins — no extra Composer dependencies required.
+ *
+ * The format produced:
+ *  - First row: bold header with light-blue background (#4A90D9)
+ *  - Data rows: plain cells
+ *  - Last row of the "duration" column (if present): SUM formula
+ *  - Column widths are estimated from the longest value in each column
+ */
+class ArrayToXLSX {
+
+	/**
+	 * Convert an array of associative arrays to XLSX binary content.
+	 *
+	 * @param array  $rows       Array of associative arrays (all rows must share the same keys)
+	 * @param string $sheetTitle Worksheet name (max 31 chars, special chars stripped)
+	 * @return string            Raw XLSX binary content ready for DataDownloadResponse
+	 */
+	static function convert(array $rows, string $sheetTitle = 'Time Report'): string {
+		// Sanitise sheet title (Excel limit: 31 chars, no /\?*[]:
+		$sheetTitle = preg_replace('/[\/\\\\\?\*\[\]\:]/', '', $sheetTitle);
+		$sheetTitle = substr($sheetTitle, 0, 31);
+		if ($sheetTitle === '') {
+			$sheetTitle = 'Sheet1';
+		}
+
+		if (empty($rows)) {
+			$headers = [];
+			$dataRows = [];
+		} else {
+			$headers = array_keys(reset($rows));
+			$dataRows = array_values($rows);
+		}
+
+		$durationColIdx = array_search('duration', $headers); // 0-based, false if absent
+		$numCols = count($headers);
+		$numDataRows = count($dataRows);
+
+		// --- Shared strings ---
+		$strings = [];
+		$stringIndex = [];
+		$addString = function (string $s) use (&$strings, &$stringIndex): int {
+			if (!isset($stringIndex[$s])) {
+				$stringIndex[$s] = count($strings);
+				$strings[] = $s;
+			}
+			return $stringIndex[$s];
+		};
+
+		// Collect header strings
+		$headerIndices = [];
+		foreach ($headers as $h) {
+			$headerIndices[] = $addString(ucfirst((string)$h));
+		}
+
+		// Collect data strings / detect numeric columns
+		$cellData = []; // [rowIdx][colIdx] => ['t' => 's'|'n'|'f', 'v' => ...]
+		foreach ($dataRows as $ri => $row) {
+			$rowValues = array_values($row);
+			foreach ($rowValues as $ci => $val) {
+				if (is_numeric($val)) {
+					$cellData[$ri][$ci] = ['t' => 'n', 'v' => $val];
+				} else {
+					$idx = $addString((string)$val);
+					$cellData[$ri][$ci] = ['t' => 's', 'v' => $idx];
+				}
+			}
+		}
+
+		// --- Column widths (estimate) ---
+		$colWidths = array_fill(0, $numCols, 10);
+		foreach ($headers as $ci => $h) {
+			$colWidths[$ci] = max($colWidths[$ci], strlen((string)$h) + 4);
+		}
+		foreach ($dataRows as $row) {
+			$rowValues = array_values($row);
+			foreach ($rowValues as $ci => $val) {
+				$colWidths[$ci] = max($colWidths[$ci], min(strlen((string)$val) + 2, 50));
+			}
+		}
+
+		// --- Build worksheet XML ---
+		$colLetters = [];
+		for ($i = 0; $i < $numCols; $i++) {
+			$colLetters[] = self::colLetter($i);
+		}
+
+		$wsXml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' . "\n";
+		$wsXml .= '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"'
+			. ' xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">' . "\n";
+
+		// Column widths
+		$wsXml .= '<cols>' . "\n";
+		for ($ci = 0; $ci < $numCols; $ci++) {
+			$n = $ci + 1;
+			$wsXml .= "<col min=\"$n\" max=\"$n\" width=\"{$colWidths[$ci]}\" customWidth=\"1\"/>\n";
+		}
+		$wsXml .= '</cols>' . "\n";
+
+		$wsXml .= '<sheetData>' . "\n";
+
+		// Header row (row 1) — style index 1 (bold+blue bg)
+		$wsXml .= '<row r="1">' . "\n";
+		foreach ($headerIndices as $ci => $si) {
+			$cell = $colLetters[$ci] . '1';
+			$wsXml .= "<c r=\"$cell\" t=\"s\" s=\"1\"><v>$si</v></c>\n";
+		}
+		$wsXml .= '</row>' . "\n";
+
+		// Data rows
+		for ($ri = 0; $ri < $numDataRows; $ri++) {
+			$rowNum = $ri + 2;
+			$wsXml .= "<row r=\"$rowNum\">\n";
+			for ($ci = 0; $ci < $numCols; $ci++) {
+				$cell = $colLetters[$ci] . $rowNum;
+				$cd = $cellData[$ri][$ci] ?? ['t' => 's', 'v' => $addString('')];
+				if ($cd['t'] === 'n') {
+					$wsXml .= "<c r=\"$cell\"><v>{$cd['v']}</v></c>\n";
+				} else {
+					$wsXml .= "<c r=\"$cell\" t=\"s\"><v>{$cd['v']}</v></c>\n";
+				}
+			}
+			$wsXml .= '</row>' . "\n";
+		}
+
+		// SUM row for duration column
+		if ($durationColIdx !== false && $numDataRows > 0) {
+			$sumRowNum = $numDataRows + 2;
+			$durationLetter = $colLetters[$durationColIdx];
+			$rangeStart = $durationLetter . '2';
+			$rangeEnd   = $durationLetter . ($numDataRows + 1);
+			$wsXml .= "<row r=\"$sumRowNum\">\n";
+			$sumCell = $durationLetter . $sumRowNum;
+			$wsXml .= "<c r=\"$sumCell\" s=\"2\"><f>SUM($rangeStart:$rangeEnd)</f></c>\n";
+			$wsXml .= '</row>' . "\n";
+		}
+
+		$wsXml .= '</sheetData>' . "\n";
+		$wsXml .= '</worksheet>';
+
+		// --- Shared strings XML ---
+		$ssCount = count($strings);
+		$ssXml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' . "\n";
+		$ssXml .= "<sst xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" count=\"$ssCount\" uniqueCount=\"$ssCount\">\n";
+		foreach ($strings as $s) {
+			$escaped = htmlspecialchars((string)$s, ENT_XML1, 'UTF-8');
+			$ssXml .= "<si><t xml:space=\"preserve\">$escaped</t></si>\n";
+		}
+		$ssXml .= '</sst>';
+
+		// --- Styles XML ---
+		// xfId 0: default
+		// xfId 1: bold + blue background (header)
+		// xfId 2: bold (SUM)
+		$stylesXml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' . "\n";
+		$stylesXml .= '<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">';
+		$stylesXml .= '<fonts count="2">';
+		$stylesXml .= '<font><sz val="11"/><name val="Calibri"/></font>'; // 0: normal
+		$stylesXml .= '<font><b/><sz val="11"/><color rgb="FFFFFFFF"/><name val="Calibri"/></font>'; // 1: bold white
+		$stylesXml .= '</fonts>';
+		$stylesXml .= '<fills count="3">';
+		$stylesXml .= '<fill><patternFill patternType="none"/></fill>'; // 0
+		$stylesXml .= '<fill><patternFill patternType="gray125"/></fill>'; // 1 (required)
+		$stylesXml .= '<fill><patternFill patternType="solid"><fgColor rgb="FF4A90D9"/></patternFill></fill>'; // 2: blue header
+		$stylesXml .= '</fills>';
+		$stylesXml .= '<borders count="1"><border><left/><right/><top/><bottom/><diagonal/></border></borders>';
+		$stylesXml .= '<cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>';
+		$stylesXml .= '<cellXfs count="3">';
+		$stylesXml .= '<xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>';  // 0: default
+		$stylesXml .= '<xf numFmtId="0" fontId="1" fillId="2" borderId="0" xfId="0" applyFont="1" applyFill="1"/>';  // 1: header
+		$stylesXml .= '<xf numFmtId="0" fontId="1" fillId="0" borderId="0" xfId="0" applyFont="1"/>';  // 2: bold SUM
+		$stylesXml .= '</cellXfs>';
+		$stylesXml .= '</styleSheet>';
+
+		// --- Assemble ZIP (XLSX is just a ZIP) ---
+		if (!class_exists('ZipArchive')) {
+			return ''; // ZipArchive not available
+		}
+
+		$tmpFile = tempnam(sys_get_temp_dir(), 'tm_xlsx_');
+		$zip = new \ZipArchive();
+		$zip->open($tmpFile, \ZipArchive::OVERWRITE);
+
+		// [Content_Types].xml
+		$zip->addFromString('[Content_Types].xml',
+			'<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' . "\n" .
+			'<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' .
+			'<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' .
+			'<Default Extension="xml" ContentType="application/xml"/>' .
+			'<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>' .
+			'<Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>' .
+			'<Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>' .
+			'<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>' .
+			'</Types>'
+		);
+
+		// _rels/.rels
+		$zip->addFromString('_rels/.rels',
+			'<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' . "\n" .
+			'<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' .
+			'<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>' .
+			'</Relationships>'
+		);
+
+		// xl/workbook.xml
+		$escapedTitle = htmlspecialchars($sheetTitle, ENT_XML1, 'UTF-8');
+		$zip->addFromString('xl/workbook.xml',
+			'<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' . "\n" .
+			'<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"' .
+			' xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">' .
+			'<sheets><sheet name="' . $escapedTitle . '" sheetId="1" r:id="rId1"/></sheets>' .
+			'</workbook>'
+		);
+
+		// xl/_rels/workbook.xml.rels
+		$zip->addFromString('xl/_rels/workbook.xml.rels',
+			'<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' . "\n" .
+			'<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' .
+			'<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>' .
+			'<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="sharedStrings.xml"/>' .
+			'<Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>' .
+			'</Relationships>'
+		);
+
+		$zip->addFromString('xl/worksheets/sheet1.xml', $wsXml);
+		$zip->addFromString('xl/sharedStrings.xml', $ssXml);
+		$zip->addFromString('xl/styles.xml', $stylesXml);
+
+		$zip->close();
+
+		$content = file_get_contents($tmpFile);
+		unlink($tmpFile);
+
+		return $content;
+	}
+
+	/**
+	 * Convert a 0-based column index to an Excel column letter (A, B, …, Z, AA, AB, …)
+	 */
+	private static function colLetter(int $index): string {
+		$letter = '';
+		while ($index >= 0) {
+			$letter = chr(65 + ($index % 26)) . $letter;
+			$index  = intval($index / 26) - 1;
+		}
+		return $letter;
+	}
+}

--- a/templates/times.php
+++ b/templates/times.php
@@ -48,6 +48,23 @@ $l = Util::getL10N('timemanager');
 							<?php print_unescaped($_['templates']['DeleteButton.svelte']); ?>
 						</span>
 					<?php } ?>
+					<?php if ($_['task']) { ?>
+						<div class="tm_object-details-item">
+							<a
+								href="<?php echo $urlGenerator->linkToRoute(
+									'timemanager.page.exportTaskXlsx',
+									[
+										'task_uuid' => $_['task']->getUuid(),
+										'timezone'  => $_['user_server_timezone'] ?? 'UTC',
+									]
+								); ?>"
+								class="button"
+								download
+							>
+								<?php p($l->t('Export Excel')); ?>
+							</a>
+						</div>
+					<?php } ?>
 				</div>
 				<div class="tm_add" data-svelte-hide="TimeEditor.svelte">
 					<div id="new-item" class="tm_new-item">


### PR DESCRIPTION
## Summary

Adds the ability to export all time entries of a specific task to an Excel (.xlsx) file, making it easy to share time tracking statistics with clients or colleagues outside of Nextcloud.

## Changes

### New file: `lib/Helper/ArrayToXLSX.php`
Pure PHP helper class that converts an array of time entries into a formatted `.xlsx` spreadsheet:
- Bold, colored header row
- Auto-sized columns
- Automatic `SUM` formula on the `duration` column
- No extra Composer dependencies (uses native PHP spreadsheet generation)

### Modified: `lib/Controller/PageController.php`
- Added `use OCA\TimeManager\Helper\ArrayToXLSX;`
- Added `exportTaskXlsx(string $task_uuid, string $timezone)` method: fetches all time entries for the given task, resolves task/project/client names and author display names, respects the user's timezone and the input method setting (decimal vs. minutes), and returns a `DataDownloadResponse` with the `.xlsx` file
- Extended `reports()` to also support `format=xlsx` (same data as CSV export, different format)

### Modified: `appinfo/routes.php`
- Added route: `GET /times/export/xlsx` → `page#exportTaskXlsx`

### Modified: `templates/times.php`
- Added an "Export Excel" button in the task detail header, visible whenever a task is selected
- The button passes `task_uuid` and the user's server timezone to the export endpoint
- Visible to all users (including read-only sharees), not just editors

## Export columns

| Column | Description |
|---|---|
| `date` | Entry date (Y-m-d) |
| `start` | Start time (H:i) |
| `end` | End time (H:i) |
| `duration` | Hours (decimal or HH:MM depending on app setting) |
| `note` | Entry note |
| `status` | `paid` / `unpaid` |
| `author` | Display name of the author |
| `task` | Task name |
| `project` | Project name |
| `client` | Client name |
